### PR TITLE
Fix for calculation bug ,dividing weight by 100

### DIFF
--- a/lib/calculator_brain.dart
+++ b/lib/calculator_brain.dart
@@ -9,7 +9,7 @@ class CalculatorBrain {
   double _bmi;
 
   String calculateBMI() {
-    _bmi = weight / pow(height, 2);
+    _bmi = weight / pow(height/100, 2);
     return _bmi.toStringAsFixed(1);
   }
 


### PR DESCRIPTION
there is no problem in the navigation or argument to fix the bug ,Height need to be in meters.
referring to stackoverflow  question https://stackoverflow.com/questions/56403011/cant-pass-data-from-home-to-results-page-by-navigator-push-method/56403427#56403427